### PR TITLE
Fix broken anchor in articles TOC

### DIFF
--- a/APIv2/articles.md
+++ b/APIv2/articles.md
@@ -38,7 +38,7 @@
     - [complete file upload](#complete-file-upload)
     - [view file information](#view-file-information)
     - [download private files](#download-private-files)
-    - [delete file from article](#delete-file--from-article)
+    - [delete file from article](#delete-file-from-article)
   - [article private links](#article-private-links-subsection)
     - [list private links](#list-private-links)
     - [create new private link](#create-new-private-link-for-this-article)


### PR DESCRIPTION
The link to the "Delete file from article" section had a superfluous dash.  Delete it.