### PR TITLE
Correction of error in CollectionPresenter key

### DIFF
--- a/docs/api/presenters/collection.md
+++ b/docs/api/presenters/collection.md
@@ -63,7 +63,7 @@ eventually commit to the new fields by documenting and guaranteeing them.
     "authors": [AuthorPresenter],
     "institution_id": 154,
     "group_id": 445,
-    "article_count": 100,
+    "articles_count": 100,
     "public": 1,
     "custom_metadata": [
         {


### PR DESCRIPTION
The number of articles in collection presenter key was 'article_count', needs to be 'articles_count' to work.