### PR TITLE
fix: security — bump lxml to 6.1.0 (CVE-2026-41066)

### DIFF
--- a/swagger_documentation/requirements.txt
+++ b/swagger_documentation/requirements.txt
@@ -2,7 +2,7 @@
 black==22.10.0
 
 # Swagger/API documentation parsing
-lxml==5.3.0
+lxml==6.1.0
 
 # API docs generation
 pyyaml==6.0.3


### PR DESCRIPTION
## Security fix

Automated vulnerability remediation via `/vuln-fix` skill.

### Alerts addressed

- [HIGH] lxml — CVE-2026-41066 — bump 5.3.0 → 6.1.0 (swagger_documentation/requirements.txt)

### Notes

- Build-time only dependency. CI must pass before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)