### PR TITLE
fix: security — bump lxml, black in swagger_documentation (CVE-2026-41066, CVE-2026-32274)

### DIFF
--- a/swagger_documentation/requirements.txt
+++ b/swagger_documentation/requirements.txt
@@ -1,8 +1,8 @@
 # Code formatting
-black==22.10.0
+black==26.3.1
 
 # Swagger/API documentation parsing
-lxml==5.3.0
+lxml==6.1.0
 
 # API docs generation
 pyyaml==6.0.3


### PR DESCRIPTION
## Security fix

Automated vulnerability remediation via `/vuln-fix` skill.

### Alerts addressed

- [HIGH] lxml — CVE-2026-41066 — Default configuration of iterparse() and ETCompatXMLParser() allows XXE to local files — pinned to 6.1.0
- [HIGH] black — CVE-2026-32274 — Arbitrary file writes from unsanitized user input in cache file name — pinned to 26.3.1

### Notes

- Changes are in `swagger_documentation/requirements.txt` only.
- CI must pass before merging.
- black 26.3.1 produced no formatting changes on this repo.
- All versions are pinned exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)