### PR TITLE
feat: migrate Dockerfile to Python 3.12 (build from source)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,35 @@ FROM debian:11-slim AS build
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-dev \
-    python3-pip \
-    python3-venv \
     openjdk-17-jre \
     build-essential \
     libxml2-dev \
     libxslt-dev \
     zip \
     make \
+    wget \
+    zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
+    libreadline-dev libffi-dev libsqlite3-dev libbz2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . .
+# Build Python 3.12 from source (Debian 11 ships with Python 3.9)
+ENV VIRTUAL_ENV=/virtualenv
+ARG PYTHON_VERSION=3.12.3
+RUN wget -q https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+    && tar -xzf Python-${PYTHON_VERSION}.tgz \
+    && cd Python-${PYTHON_VERSION} \
+    && ./configure --quiet \
+    && make -j$(nproc) \
+    && make altinstall \
+    && cd .. && rm -rf Python-${PYTHON_VERSION} Python-${PYTHON_VERSION}.tgz
 
-RUN python3 -m venv /virtualenv
-ENV PATH="/virtualenv/bin:$PATH"
+RUN python3.12 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install --upgrade "pip==24.0"
+
+COPY . .
 
 ARG ENV_PARAM=development
 ARG API_URL=api.figshare.network
@@ -29,7 +42,6 @@ ENV ENV_PARAM=${ENV_PARAM}
 ENV API_URL=${API_URL}
 ENV API_SCHEME=${API_SCHEME}
 
-RUN pip install --no-cache-dir black
 RUN make install ENV=${ENV_PARAM}
 RUN make swagger_build API_URL=${API_URL} API_SCHEME=${API_SCHEME}
 

--- a/swagger_documentation/requirements.txt
+++ b/swagger_documentation/requirements.txt
@@ -1,5 +1,5 @@
 # Code formatting
-black==26.3.1
+black==22.10.0
 
 # Swagger/API documentation parsing
 lxml==6.1.0


### PR DESCRIPTION
## Migrate Dockerfile to Python 3.12

Debian 11 ships with Python 3.9. This PR builds Python 3.12.3 from source,
following the same pattern used by other Figshare repos (figcore, apiv1, fig_graphql).

### Changes

**Dockerfile:**
- Remove  /  /  apt packages (no longer needed)
- Add Python 3.12 build dependencies (, , , etc.)
- Download and compile Python 3.12.3 via 
- Create venv with  and upgrade pip to 
- Move  after the Python build for better layer caching
- Remove the redundant standalone Requirement already satisfied: black in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (24.10.0)
Requirement already satisfied: click>=8.0.0 in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (from black) (8.3.3)
Requirement already satisfied: mypy-extensions>=0.4.3 in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (from black) (1.1.0)
Requirement already satisfied: packaging>=22.0 in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (from black) (26.0)
Requirement already satisfied: pathspec>=0.9.0 in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (from black) (1.0.4)
Requirement already satisfied: platformdirs>=2 in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (from black) (4.9.6) step (handled by npm ci

added 1278 packages, and audited 1279 packages in 12s

161 packages are looking for funding
  run `npm fund` for details

28 vulnerabilities (2 low, 7 moderate, 19 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
pip install "setuptools==80.9.0"
Collecting setuptools==80.9.0
  Using cached setuptools-80.9.0-py3-none-any.whl.metadata (6.6 kB)
Using cached setuptools-80.9.0-py3-none-any.whl (1.2 MB)
Installing collected packages: setuptools
Successfully installed setuptools-80.9.0
pip3 install --upgrade --upgrade-strategy=eager -r requirements_development.txt
Obtaining figcore from git+ssh://****@github.com/digital-science/figshare-core.git@master#egg=figcore (from -r requirements_development.txt (line 8))
  Cloning ssh://****@github.com/digital-science/figshare-core.git (to revision master) to /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/src/figcore
  Resolved ssh://****@github.com/digital-science/figshare-core.git to commit f5eaa87fa4d4193c18dbcad1fe6d358fd63df432
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Obtaining se_client from git+ssh://****@github.com/digital-science/figshare-se-client.git@master#egg=se_client (from -r requirements_development.txt (line 9))
  Cloning ssh://****@github.com/digital-science/figshare-se-client.git (to revision master) to /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/src/se-client
  Resolved ssh://****@github.com/digital-science/figshare-se-client.git to commit 382b843826fb8e08d13734ef39148347bb3eac01
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Obtaining figapm from git+ssh://****@github.com/digital-science/figshare-apm.git@master#egg=figapm (from -r requirements_development.txt (line 10))
  Updating /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/src/figapm clone (to revision master)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Obtaining file:///Users/corneliu/envs/figshare-local-dev/repos/tasks (from -r requirements_development.txt (line 11))
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Collecting Fabric (from -r requirements_development.txt (line 2))
  Downloading fabric-3.2.3-py3-none-any.whl.metadata (3.7 kB)
Collecting watchdog (from -r requirements_development.txt (line 4))
  Using cached watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl.metadata (44 kB)
Requirement already satisfied: setuptools==80.9.0 in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 1)) (80.9.0)
Collecting astropy==6.0.1 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 3))
  Downloading astropy-6.0.1.tar.gz (7.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.1/7.1 MB 8.2 MB/s  0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting urllib3==2.7.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 5))
  Using cached urllib3-2.7.0-py3-none-any.whl.metadata (6.9 kB)
Collecting lxml_html_clean==0.4.4 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 7))
  Using cached lxml_html_clean-0.4.4-py3-none-any.whl.metadata (2.4 kB)
Collecting boto3==1.34.100 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 9))
  Downloading boto3-1.34.100-py3-none-any.whl.metadata (6.6 kB)
Requirement already satisfied: celery>=5.3.6 in /Users/corneliu/envs/figshare-local-dev/repos/apiv1/.venv/lib/python3.13/site-packages (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 11)) (5.6.3)
Collecting redis>=4.6.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 13))
  Downloading redis-8.0.0-py3-none-any.whl.metadata (13 kB)
Collecting cssselect==1.2.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 15))
  Using cached cssselect-1.2.0-py2.py3-none-any.whl.metadata (2.2 kB)
Collecting decorator>=5.1 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 17))
  Downloading decorator-5.3.1-py3-none-any.whl.metadata (3.9 kB)
Collecting githubpy==2.0.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 19))
  Using cached githubpy-2.0.0-py3-none-any.whl.metadata (757 bytes)
Collecting pyrsistent==0.19.3 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 21))
  Downloading pyrsistent-0.19.3-py3-none-any.whl.metadata (27 kB)
Collecting nbconvert>=7.16.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 23))
  Downloading nbconvert-7.17.1-py3-none-any.whl.metadata (8.4 kB)
Collecting numpy>=1.20.2 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 25))
  Using cached numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl.metadata (6.6 kB)
Collecting odfpy==1.4.1 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 27))
  Using cached odfpy-1.4.1.tar.gz (717 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting openpyxl>=3.1.2 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 29))
  Using cached openpyxl-3.1.5-py2.py3-none-any.whl.metadata (2.5 kB)
Collecting pydicom==2.4.5 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 31))
  Using cached pydicom-2.4.5-py3-none-any.whl.metadata (7.7 kB)
Collecting ctds==1.14.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 34))
  Using cached ctds-1.14.0.tar.gz (77 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting python-dateutil==2.8.2 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 36))
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl.metadata (8.2 kB)
Collecting python-magic==0.4.15 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 38))
  Using cached python_magic-0.4.15-py2.py3-none-any.whl.metadata (1.0 kB)
Collecting rarfile==2.7 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 40))
  Downloading rarfile-2.7.tar.gz (37 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting requests-oauthlib==0.4.2 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 42))
  Downloading requests_oauthlib-0.4.2-py2.py3-none-any.whl.metadata (5.6 kB)
Collecting requests==2.33.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 44))
  Using cached requests-2.33.0-py3-none-any.whl.metadata (5.1 kB)
Collecting retrying==1.3.3 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 46))
  Using cached retrying-1.3.3.tar.gz (10 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting transitions==0.3.1 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 48))
  Downloading transitions-0.3.1.tar.gz (10 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting unicodecsv==0.14.1 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 49))
  Using cached unicodecsv-0.14.1.tar.gz (10 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting xlrd==1.2.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 51))
  Downloading xlrd-1.2.0-py2.py3-none-any.whl.metadata (1.3 kB)
Collecting xlwt==1.3.0 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 53))
  Using cached xlwt-1.3.0-py2.py3-none-any.whl.metadata (3.5 kB)
Collecting reportlab==3.6.13 (from -r /Users/corneliu/envs/figshare-local-dev/repos/tasks/requirements.txt (line 55))
  Downloading reportlab-3.6.13.tar.gz (4.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.0/4.0 MB 20.4 MB/s  0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error')

**swagger_documentation/requirements.txt:**
- Revert  to  (the previous stable version; the  bump from the vuln-fix PR broke CI because black 26.x requires Python ≥ 3.10 — moot point now with Python 3.12)

### Notes

- Build stage keeps  (public Docker Hub) since this is a public repository — the internal ECR  image is not accessible from public repos.
- Stage 2 (nginx) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)