### PR TITLE
chore: upgrade to Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 # Stage 1: Build the static documentation assets
-FROM debian:11-slim AS build
+FROM python:3.12-slim AS build
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-dev \
-    python3-pip \
-    python3-venv \
-    openjdk-17-jre \
+    openjdk-21-jre \
     build-essential \
     libxml2-dev \
     libxslt-dev \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install:
 .PHONY: install
 
 format:
-	black -l 120 -t py39 ./swagger_documentation
+	black -l 120 -t py312 ./swagger_documentation
 .PHONY: format
 
 server:


### PR DESCRIPTION
## Summary

- Switch Dockerfile base image from `debian:11-slim` to `python:3.12-slim`
- Remove redundant `python3-dev`, `python3-pip`, `python3-venv` packages (included in the official Python image)
- Upgrade `openjdk-17-jre` → `openjdk-21-jre` (`openjdk-17` is not available on Debian Trixie, which `python:3.12-slim` is based on)
- Update `black` target flag from `-t py39` to `-t py312` in Makefile

## Test plan

- [ ] Docker build completes successfully
- [ ] `make format` runs without errors
- [ ] `make swagger_build` produces expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)