### PR TITLE
FIG-45731: document missing fields in API v2 response schemas

### DIFF
--- a/swagger_documentation/docs/components/v2.0/schemas.yaml
+++ b/swagger_documentation/docs/components/v2.0/schemas.yaml
@@ -316,6 +316,18 @@ schemas:
         type: string
         description: Date when article was created
         example: '2017-05-18T11:49:03Z'
+      modified_date:
+        type: string
+        description: Date when article was last modified
+        example: '2017-05-18T11:49:03Z'
+      published_date:
+        type: string
+        description: Date when article was first published, null if not published
+        example: '2017-05-18T11:49:03Z'
+      group_id:
+        type: integer
+        description: Group ID of the article
+        example: 1
     x-tag: articles
   ArticleComplete:
     required:
@@ -378,6 +390,10 @@ schemas:
         type: string
         description: Curation status of the article
         example: approved
+      group_resource_id:
+        type: string
+        description: Group resource ID of the article
+        example: ''
     allOf:
     - $ref: '#/components/schemas/ArticleComplete'
     x-tag: articles
@@ -744,6 +760,17 @@ schemas:
         type: boolean
         description: True if embargoed
         example: true
+      embargo_date:
+        type: string
+        description: Date when the embargo expires and the article gets published, null if not embargoed
+        example: '2018-05-22T04:04:04'
+      embargo_type:
+        type: string
+        description: 'Embargo level. Possible values: article, file'
+        example: file
+        enum:
+        - article
+        - file
       embargo_title:
         type: string
         description: Title for embargo
@@ -1442,6 +1469,10 @@ schemas:
         example: https://api.figshare.com/v2/collections/123
       timeline:
         $ref: '#/components/schemas/Timeline'
+      published_date:
+        type: string
+        description: Date when collection was first published, null if not published
+        example: '2017-05-15T15:12:26Z'
     x-tag: collections
   CollectionComplete:
     required:
@@ -1594,6 +1625,10 @@ schemas:
           related_materials → [{id, title, relation, identifier, identifier_type}];
           categories → [{id, title, parent_id, path, source_id, taxonomy_id}].
         additionalProperties: {}
+      group_resource_id:
+        type: string
+        description: Group resource ID of the collection
+        example: ''
     allOf:
     - $ref: '#/components/schemas/Collection'
     x-tag: collections
@@ -1752,6 +1787,10 @@ schemas:
           related_materials → [{id, title, relation, identifier, identifier_type}];
           categories → [{id, title, parent_id, path, source_id, taxonomy_id}].
         additionalProperties: {}
+      group_resource_id:
+        type: string
+        description: Group resource ID of the collection
+        example: ''
     allOf:
     - $ref: '#/components/schemas/Collection'
     x-tag: collections
@@ -2309,6 +2348,10 @@ schemas:
       resolution_comment:
         type: string
         description: The resolution comment of the review.
+      review_date:
+        type: string
+        description: The date of the review.
+        example: '2021-11-16T13:03:38'
     x-tag: institutions
   CurationComment:
     required:
@@ -2593,6 +2636,10 @@ schemas:
         type: string
         description: Institution name
         example: Institution
+      domain:
+        type: string
+        description: Institution domain
+        example: institution.edu
     x-tag: institutions
   InstitutionAccountsSearch:
     type: object
@@ -2884,6 +2931,10 @@ schemas:
         type: boolean
         description: True if the file is attached to a public item version
         example: true
+      status:
+        type: string
+        description: File status
+        example: available
     allOf:
     - $ref: '#/components/schemas/PublicFile'
     x-tag: common
@@ -3103,6 +3154,10 @@ schemas:
         type: string
         description: Date when project was last modified
         example: '2017-05-16T14:52:54Z'
+      published_date:
+        type: string
+        description: Date when project was first published, null if not published
+        example: '2017-05-16T14:52:54Z'
     x-tag: projects
   ProjectArticle:
     required:
@@ -3223,6 +3278,17 @@ schemas:
         type: string
         description: Reason for embargo
         example: not complete
+      embargo_date:
+        type: string
+        description: Date when the embargo expires and the article gets published, null if not embargoed
+        example: '2018-05-22T04:04:04'
+      embargo_type:
+        type: string
+        description: 'Embargo level. Possible values: article, file'
+        example: file
+        enum:
+        - article
+        - file
       references:
         type: array
         description: List of references
@@ -3344,6 +3410,11 @@ schemas:
           Item-type based metadata stock field values keyed by field name (e.g. funding_list).
           Only present when the project belongs to an institution with item-type based metadata enabled.
         additionalProperties: {}
+      figshare_url:
+        type: string
+        description: Project public url
+        format: url
+        example: https://figshare.com/projects/project_name/1
     allOf:
     - $ref: '#/components/schemas/Project'
     x-tag: projects
@@ -3424,6 +3495,11 @@ schemas:
           Item-type based metadata stock field values keyed by field name (e.g. funding_list).
           Only present when the project belongs to an institution with item-type based metadata enabled.
         additionalProperties: {}
+      figshare_url:
+        type: string
+        description: Project public url
+        format: url
+        example: https://figshare.com/projects/project_name/1
     allOf:
     - $ref: '#/components/schemas/ProjectPrivate'
     x-tag: projects

--- a/swagger_documentation/docs/versions/swagger_v2.0.json
+++ b/swagger_documentation/docs/versions/swagger_v2.0.json
@@ -12420,6 +12420,21 @@
                         "type": "string",
                         "description": "Date when article was created",
                         "example": "2017-05-18T11:49:03Z"
+                    },
+                    "modified_date": {
+                        "type": "string",
+                        "description": "Date when article was last modified",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when article was first published, null if not published",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "group_id": {
+                        "type": "integer",
+                        "description": "Group ID of the article",
+                        "example": 1
                     }
                 },
                 "x-tag": "articles"
@@ -12505,6 +12520,11 @@
                         "type": "string",
                         "description": "Curation status of the article",
                         "example": "approved"
+                    },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the article",
+                        "example": ""
                     }
                 },
                 "allOf": [
@@ -12946,6 +12966,20 @@
                         "type": "boolean",
                         "description": "True if embargoed",
                         "example": true
+                    },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
                     },
                     "embargo_title": {
                         "type": "string",
@@ -13861,6 +13895,11 @@
                     },
                     "timeline": {
                         "$ref": "#/components/schemas/Timeline"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when collection was first published, null if not published",
+                        "example": "2017-05-15T15:12:26Z"
                     }
                 },
                 "x-tag": "collections"
@@ -14044,6 +14083,11 @@
                         "type": "object",
                         "description": "Item-type based metadata field values keyed by field name. Only present when the collection belongs to an institution with item-type based metadata enabled. Scalar/text stock fields (e.g. publisher) and custom fields are returned as-is. Relational fields are hydrated on GET as follows: authors → [{id, name, first_name, last_name, is_active, url_name, orcid_id, affiliations}]; funding_list → [{id, title, grant_code, funder_name, is_user_defined, url}] (url only when a Dimensions grant id exists); related_materials → [{id, title, relation, identifier, identifier_type}]; categories → [{id, title, parent_id, path, source_id, taxonomy_id}].",
                         "additionalProperties": {}
+                    },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the collection",
+                        "example": ""
                     }
                 },
                 "allOf": [
@@ -14237,6 +14281,11 @@
                         "type": "object",
                         "description": "Item-type based metadata field values keyed by field name. Only present when the collection belongs to an institution with item-type based metadata enabled. Scalar/text stock fields (e.g. publisher) and custom fields are returned as-is. Relational fields are hydrated on GET as follows: authors → [{id, name, first_name, last_name, is_active, url_name, orcid_id, affiliations}]; funding_list → [{id, title, grant_code, funder_name, is_user_defined, url}] (url only when a Dimensions grant id exists); related_materials → [{id, title, relation, identifier, identifier_type}]; categories → [{id, title, parent_id, path, source_id, taxonomy_id}].",
                         "additionalProperties": {}
+                    },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the collection",
+                        "example": ""
                     }
                 },
                 "allOf": [
@@ -14962,6 +15011,11 @@
                     "resolution_comment": {
                         "type": "string",
                         "description": "The resolution comment of the review."
+                    },
+                    "review_date": {
+                        "type": "string",
+                        "description": "The date of the review.",
+                        "example": "2021-11-16T13:03:38"
                     }
                 },
                 "x-tag": "institutions"
@@ -15342,6 +15396,11 @@
                         "type": "string",
                         "description": "Institution name",
                         "example": "Institution"
+                    },
+                    "domain": {
+                        "type": "string",
+                        "description": "Institution domain",
+                        "example": "institution.edu"
                     }
                 },
                 "x-tag": "institutions"
@@ -15716,6 +15775,11 @@
                         "type": "boolean",
                         "description": "True if the file is attached to a public item version",
                         "example": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "File status",
+                        "example": "available"
                     }
                 },
                 "allOf": [
@@ -16007,6 +16071,11 @@
                         "type": "string",
                         "description": "Date when project was last modified",
                         "example": "2017-05-16T14:52:54Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when project was first published, null if not published",
+                        "example": "2017-05-16T14:52:54Z"
                     }
                 },
                 "x-tag": "projects"
@@ -16157,6 +16226,20 @@
                         "type": "string",
                         "description": "Reason for embargo",
                         "example": "not complete"
+                    },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
                     },
                     "references": {
                         "type": "array",
@@ -16316,6 +16399,12 @@
                         "type": "object",
                         "description": "Item-type based metadata stock field values keyed by field name (e.g. funding_list). Only present when the project belongs to an institution with item-type based metadata enabled.",
                         "additionalProperties": {}
+                    },
+                    "figshare_url": {
+                        "type": "string",
+                        "description": "Project public url",
+                        "format": "url",
+                        "example": "https://figshare.com/projects/project_name/1"
                     }
                 },
                 "allOf": [
@@ -16417,6 +16506,12 @@
                         "type": "object",
                         "description": "Item-type based metadata stock field values keyed by field name (e.g. funding_list). Only present when the project belongs to an institution with item-type based metadata enabled.",
                         "additionalProperties": {}
+                    },
+                    "figshare_url": {
+                        "type": "string",
+                        "description": "Project public url",
+                        "format": "url",
+                        "example": "https://figshare.com/projects/project_name/1"
                     }
                 },
                 "allOf": [

--- a/swagger_documentation/swagger.json
+++ b/swagger_documentation/swagger.json
@@ -12420,6 +12420,21 @@
                         "type": "string",
                         "description": "Date when article was created",
                         "example": "2017-05-18T11:49:03Z"
+                    },
+                    "modified_date": {
+                        "type": "string",
+                        "description": "Date when article was last modified",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when article was first published, null if not published",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "group_id": {
+                        "type": "integer",
+                        "description": "Group ID of the article",
+                        "example": 1
                     }
                 },
                 "x-tag": "articles"
@@ -12505,6 +12520,11 @@
                         "type": "string",
                         "description": "Curation status of the article",
                         "example": "approved"
+                    },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the article",
+                        "example": ""
                     }
                 },
                 "allOf": [
@@ -12946,6 +12966,20 @@
                         "type": "boolean",
                         "description": "True if embargoed",
                         "example": true
+                    },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
                     },
                     "embargo_title": {
                         "type": "string",
@@ -13861,6 +13895,11 @@
                     },
                     "timeline": {
                         "$ref": "#/components/schemas/Timeline"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when collection was first published, null if not published",
+                        "example": "2017-05-15T15:12:26Z"
                     }
                 },
                 "x-tag": "collections"
@@ -14044,6 +14083,11 @@
                         "type": "object",
                         "description": "Item-type based metadata field values keyed by field name. Only present when the collection belongs to an institution with item-type based metadata enabled. Scalar/text stock fields (e.g. publisher) and custom fields are returned as-is. Relational fields are hydrated on GET as follows: authors \u2192 [{id, name, first_name, last_name, is_active, url_name, orcid_id, affiliations}]; funding_list \u2192 [{id, title, grant_code, funder_name, is_user_defined, url}] (url only when a Dimensions grant id exists); related_materials \u2192 [{id, title, relation, identifier, identifier_type}]; categories \u2192 [{id, title, parent_id, path, source_id, taxonomy_id}].",
                         "additionalProperties": {}
+                    },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the collection",
+                        "example": ""
                     }
                 },
                 "allOf": [
@@ -14237,6 +14281,11 @@
                         "type": "object",
                         "description": "Item-type based metadata field values keyed by field name. Only present when the collection belongs to an institution with item-type based metadata enabled. Scalar/text stock fields (e.g. publisher) and custom fields are returned as-is. Relational fields are hydrated on GET as follows: authors \u2192 [{id, name, first_name, last_name, is_active, url_name, orcid_id, affiliations}]; funding_list \u2192 [{id, title, grant_code, funder_name, is_user_defined, url}] (url only when a Dimensions grant id exists); related_materials \u2192 [{id, title, relation, identifier, identifier_type}]; categories \u2192 [{id, title, parent_id, path, source_id, taxonomy_id}].",
                         "additionalProperties": {}
+                    },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the collection",
+                        "example": ""
                     }
                 },
                 "allOf": [
@@ -14962,6 +15011,11 @@
                     "resolution_comment": {
                         "type": "string",
                         "description": "The resolution comment of the review."
+                    },
+                    "review_date": {
+                        "type": "string",
+                        "description": "The date of the review.",
+                        "example": "2021-11-16T13:03:38"
                     }
                 },
                 "x-tag": "institutions"
@@ -15342,6 +15396,11 @@
                         "type": "string",
                         "description": "Institution name",
                         "example": "Institution"
+                    },
+                    "domain": {
+                        "type": "string",
+                        "description": "Institution domain",
+                        "example": "institution.edu"
                     }
                 },
                 "x-tag": "institutions"
@@ -15716,6 +15775,11 @@
                         "type": "boolean",
                         "description": "True if the file is attached to a public item version",
                         "example": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "File status",
+                        "example": "available"
                     }
                 },
                 "allOf": [
@@ -16007,6 +16071,11 @@
                         "type": "string",
                         "description": "Date when project was last modified",
                         "example": "2017-05-16T14:52:54Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when project was first published, null if not published",
+                        "example": "2017-05-16T14:52:54Z"
                     }
                 },
                 "x-tag": "projects"
@@ -16157,6 +16226,20 @@
                         "type": "string",
                         "description": "Reason for embargo",
                         "example": "not complete"
+                    },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
                     },
                     "references": {
                         "type": "array",
@@ -16316,6 +16399,12 @@
                         "type": "object",
                         "description": "Item-type based metadata stock field values keyed by field name (e.g. funding_list). Only present when the project belongs to an institution with item-type based metadata enabled.",
                         "additionalProperties": {}
+                    },
+                    "figshare_url": {
+                        "type": "string",
+                        "description": "Project public url",
+                        "format": "url",
+                        "example": "https://figshare.com/projects/project_name/1"
                     }
                 },
                 "allOf": [
@@ -16417,6 +16506,12 @@
                         "type": "object",
                         "description": "Item-type based metadata stock field values keyed by field name (e.g. funding_list). Only present when the project belongs to an institution with item-type based metadata enabled.",
                         "additionalProperties": {}
+                    },
+                    "figshare_url": {
+                        "type": "string",
+                        "description": "Project public url",
+                        "format": "url",
+                        "example": "https://figshare.com/projects/project_name/1"
                     }
                 },
                 "allOf": [

--- a/swagger_documentation/swagger_parsed.json
+++ b/swagger_documentation/swagger_parsed.json
@@ -12420,6 +12420,21 @@
                         "type": "string",
                         "description": "Date when article was created",
                         "example": "2017-05-18T11:49:03Z"
+                    },
+                    "modified_date": {
+                        "type": "string",
+                        "description": "Date when article was last modified",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when article was first published, null if not published",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "group_id": {
+                        "type": "integer",
+                        "description": "Group ID of the article",
+                        "example": 1
                     }
                 },
                 "x-tag": "articles"
@@ -12603,6 +12618,20 @@
                         "description": "Reason for embargo",
                         "example": "not complete"
                     },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
+                    },
                     "references": {
                         "type": "array",
                         "description": "List of references",
@@ -12655,6 +12684,11 @@
                         "type": "string",
                         "description": "Curation status of the article",
                         "example": "approved"
+                    },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the article",
+                        "example": ""
                     },
                     "figshare_url": {
                         "type": "string",
@@ -12823,6 +12857,20 @@
                         "type": "string",
                         "description": "Reason for embargo",
                         "example": "not complete"
+                    },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
                     },
                     "references": {
                         "type": "array",
@@ -13293,6 +13341,20 @@
                         "type": "boolean",
                         "description": "True if embargoed",
                         "example": true
+                    },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
                     },
                     "embargo_title": {
                         "type": "string",
@@ -14052,6 +14114,21 @@
                         "type": "string",
                         "description": "Date when article was created",
                         "example": "2017-05-18T11:49:03Z"
+                    },
+                    "modified_date": {
+                        "type": "string",
+                        "description": "Date when article was last modified",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when article was first published, null if not published",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "group_id": {
+                        "type": "integer",
+                        "description": "Group ID of the article",
+                        "example": 1
                     }
                 },
                 "allOf": [
@@ -14413,6 +14490,11 @@
                     },
                     "timeline": {
                         "$ref": "#/components/schemas/Timeline"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when collection was first published, null if not published",
+                        "example": "2017-05-15T15:12:26Z"
                     }
                 },
                 "x-tag": "collections"
@@ -14597,6 +14679,11 @@
                         "description": "Item-type based metadata field values keyed by field name. Only present when the collection belongs to an institution with item-type based metadata enabled. Scalar/text stock fields (e.g. publisher) and custom fields are returned as-is. Relational fields are hydrated on GET as follows: authors \u2192 [{id, name, first_name, last_name, is_active, url_name, orcid_id, affiliations}]; funding_list \u2192 [{id, title, grant_code, funder_name, is_user_defined, url}] (url only when a Dimensions grant id exists); related_materials \u2192 [{id, title, relation, identifier, identifier_type}]; categories \u2192 [{id, title, parent_id, path, source_id, taxonomy_id}].",
                         "additionalProperties": {}
                     },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the collection",
+                        "example": ""
+                    },
                     "id": {
                         "type": "integer",
                         "description": "Collection id",
@@ -14621,6 +14708,11 @@
                         "type": "string",
                         "description": "Api endpoint",
                         "example": "https://api.figshare.com/v2/collections/123"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when collection was first published, null if not published",
+                        "example": "2017-05-15T15:12:26Z"
                     }
                 },
                 "allOf": [
@@ -14815,6 +14907,11 @@
                         "description": "Item-type based metadata field values keyed by field name. Only present when the collection belongs to an institution with item-type based metadata enabled. Scalar/text stock fields (e.g. publisher) and custom fields are returned as-is. Relational fields are hydrated on GET as follows: authors \u2192 [{id, name, first_name, last_name, is_active, url_name, orcid_id, affiliations}]; funding_list \u2192 [{id, title, grant_code, funder_name, is_user_defined, url}] (url only when a Dimensions grant id exists); related_materials \u2192 [{id, title, relation, identifier, identifier_type}]; categories \u2192 [{id, title, parent_id, path, source_id, taxonomy_id}].",
                         "additionalProperties": {}
                     },
+                    "group_resource_id": {
+                        "type": "string",
+                        "description": "Group resource ID of the collection",
+                        "example": ""
+                    },
                     "id": {
                         "type": "integer",
                         "description": "Collection id",
@@ -14839,6 +14936,11 @@
                         "type": "string",
                         "description": "Api endpoint",
                         "example": "https://api.figshare.com/v2/collections/123"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when collection was first published, null if not published",
+                        "example": "2017-05-15T15:12:26Z"
                     }
                 },
                 "allOf": [
@@ -15628,6 +15730,11 @@
                     "resolution_comment": {
                         "type": "string",
                         "description": "The resolution comment of the review."
+                    },
+                    "review_date": {
+                        "type": "string",
+                        "description": "The date of the review.",
+                        "example": "2021-11-16T13:03:38"
                     }
                 },
                 "x-tag": "institutions"
@@ -15752,6 +15859,11 @@
                     "resolution_comment": {
                         "type": "string",
                         "description": "The resolution comment of the review."
+                    },
+                    "review_date": {
+                        "type": "string",
+                        "description": "The date of the review.",
+                        "example": "2021-11-16T13:03:38"
                     }
                 },
                 "allOf": [
@@ -16062,6 +16174,11 @@
                         "type": "string",
                         "description": "Institution name",
                         "example": "Institution"
+                    },
+                    "domain": {
+                        "type": "string",
+                        "description": "Institution domain",
+                        "example": "institution.edu"
                     }
                 },
                 "x-tag": "institutions"
@@ -16634,6 +16751,11 @@
                         "description": "True if the file is attached to a public item version",
                         "example": true
                     },
+                    "status": {
+                        "type": "string",
+                        "description": "File status",
+                        "example": "available"
+                    },
                     "id": {
                         "type": "integer",
                         "description": "File id",
@@ -16936,6 +17058,20 @@
                         "description": "Reason for embargo",
                         "example": "not complete"
                     },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
+                    },
                     "references": {
                         "type": "array",
                         "description": "List of references",
@@ -17115,6 +17251,11 @@
                         "type": "string",
                         "description": "Date when project was last modified",
                         "example": "2017-05-16T14:52:54Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when project was first published, null if not published",
+                        "example": "2017-05-16T14:52:54Z"
                     }
                 },
                 "x-tag": "projects"
@@ -17266,6 +17407,20 @@
                         "description": "Reason for embargo",
                         "example": "not complete"
                     },
+                    "embargo_date": {
+                        "type": "string",
+                        "description": "Date when the embargo expires and the article gets published, null if not embargoed",
+                        "example": "2018-05-22T04:04:04"
+                    },
+                    "embargo_type": {
+                        "type": "string",
+                        "description": "Embargo level. Possible values: article, file",
+                        "example": "file",
+                        "enum": [
+                            "article",
+                            "file"
+                        ]
+                    },
                     "references": {
                         "type": "array",
                         "description": "List of references",
@@ -17373,6 +17528,21 @@
                         "type": "string",
                         "description": "Deprecated by related materials. Not applicable to regular users. In a publisher case, this is the publisher article title.",
                         "default": ""
+                    },
+                    "modified_date": {
+                        "type": "string",
+                        "description": "Date when article was last modified",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when article was first published, null if not published",
+                        "example": "2017-05-18T11:49:03Z"
+                    },
+                    "group_id": {
+                        "type": "integer",
+                        "description": "Group ID of the article",
+                        "example": 1
                     }
                 },
                 "allOf": [
@@ -17504,6 +17674,12 @@
                         "description": "Item-type based metadata stock field values keyed by field name (e.g. funding_list). Only present when the project belongs to an institution with item-type based metadata enabled.",
                         "additionalProperties": {}
                     },
+                    "figshare_url": {
+                        "type": "string",
+                        "description": "Project public url",
+                        "format": "url",
+                        "example": "https://figshare.com/projects/project_name/1"
+                    },
                     "url": {
                         "type": "string",
                         "description": "Api endpoint",
@@ -17518,6 +17694,11 @@
                         "type": "string",
                         "description": "Project title",
                         "example": "project"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when project was first published, null if not published",
+                        "example": "2017-05-16T14:52:54Z"
                     }
                 },
                 "allOf": [
@@ -17619,6 +17800,12 @@
                         "type": "object",
                         "description": "Item-type based metadata stock field values keyed by field name (e.g. funding_list). Only present when the project belongs to an institution with item-type based metadata enabled.",
                         "additionalProperties": {}
+                    },
+                    "figshare_url": {
+                        "type": "string",
+                        "description": "Project public url",
+                        "format": "url",
+                        "example": "https://figshare.com/projects/project_name/1"
                     },
                     "role": {
                         "type": "string",
@@ -17867,6 +18054,11 @@
                     "modified_date": {
                         "type": "string",
                         "description": "Date when project was last modified",
+                        "example": "2017-05-16T14:52:54Z"
+                    },
+                    "published_date": {
+                        "type": "string",
+                        "description": "Date when project was first published, null if not published",
                         "example": "2017-05-16T14:52:54Z"
                     }
                 },


### PR DESCRIPTION
## Summary

[FIG-45731](https://digital-science.atlassian.net/browse/FIG-45731): several fields are returned by API v2 responses but were never documented in the OpenAPI schemas. This adds them at the correct point in each inheritance chain so every field surfaces on exactly the endpoints that return it (and nowhere else).

## Changes

Source edited: `swagger_documentation/docs/components/v2.0/schemas.yaml`. Generated artifacts regenerated via `make docs swagger`.

| Schema | Fields added |
|--------|--------------|
| `Article` (base) | `published_date`, `modified_date`, `group_id` |
| `ProjectArticle` | `embargo_date`, `embargo_type` |
| `ArticleCompletePrivate` | `group_resource_id` |
| `ArticleEmbargo` | `embargo_date`, `embargo_type` |
| `Collection` (base) | `published_date` |
| `CollectionComplete` | `group_resource_id` |
| `CollectionCompletePrivate` | `group_resource_id` |
| `Project` (base) | `published_date` |
| `ProjectComplete` | `figshare_url` |
| `ProjectCompletePrivate` | `figshare_url` |
| `Curation` | `review_date` |
| `PrivateFile` | `status` |
| `Institution` | `domain` |

### Why these placements

The schemas use `allOf` inheritance, so adding a field once cascades to all sub-schemas:

- `Article` → `ProjectArticle` → `ArticleComplete` → `ArticleCompletePrivate`. Adding `published_date`/`modified_date`/`group_id` to the base `Article` covers all list, search, collection-article, project-article and institution-article endpoints **and** the complete views.
- `embargo_date`/`embargo_type` go on `ProjectArticle` (which already holds `is_embargoed`/`embargo_title`/`embargo_reason`), so they reach the complete views but not the short list.
- `CollectionComplete` and `CollectionCompletePrivate` both inherit directly from `Collection` (not from one another), so `group_resource_id` is added to both.
- `figshare_url` is added to both `ProjectComplete` and `ProjectCompletePrivate` (they don't share a complete-level ancestor).
- `Curation` covers both the review list and `CurationDetail` (which inherits from it).

All fields are added as optional properties (not `required`), since `published_date`/`embargo_date` can be `null` for unpublished / non-embargoed items.

## Note for reviewer

`group_resource_id` is added only to the **private** article schemas (`ArticleCompletePrivate`), per the ticket, which lists it for `retrieve_private_item` and `retrieve_private_project_article` but **not** for the public `retrieve_public_item`. If the public article endpoint also returns it, the field should move up to `ProjectArticle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FIG-45731]: https://digital-science.atlassian.net/browse/FIG-45731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ